### PR TITLE
making default header application/json

### DIFF
--- a/Orbiter/Orbiter.m
+++ b/Orbiter/Orbiter.m
@@ -174,7 +174,7 @@ static NSString * const kUrbanAirshipAPIBaseURLString = @"https://go.urbanairshi
         return nil;
     }
 
-    [self.HTTPClient setDefaultHeader:@"Accept" value:@"*/*"];
+    [self.HTTPClient setDefaultHeader:@"Accept" value:@"application/json"];
 
     return self;
 }


### PR DESCRIPTION
...complaining about

UrbanAirship was complaining about the content type, not being one of the following; 
- text/json
- application/json
- text/javascript

it seems to be defaulting to text/plain which causes Urban Airship to throw an error causing the error block to always be executed, the device still does register though. 

```
2013-05-20 18:38:31.133 Neckbeard[9426:907] Registration Error: Error Domain=AFNetworkingErrorDomain Code=-1016 "Expected content type {(
    "text/json",
    "application/json",
    "text/javascript"
)}, got text/plain" UserInfo=0x1fd52d80 {NSLocalizedRecoverySuggestion=OK, AFNetworkingOperationFailingURLRequestErrorKey=<NSMutableURLRequest https://go.urbanairship.com/api/device_tokens/<token>>, NSErrorFailingURLKey=https://go.urbanairship.com/api/device_tokens/<token>, NSLocalizedDescription=Expected content type {(
    "text/json",
    "application/json",
    "text/javascript"
)}, got text/plain, AFNetworkingOperationFailingURLResponseErrorKey=<NSHTTPURLResponse: 0x1fd0f700>}
```
