### PR TITLE
Use json/application Content-Type headers for payload in ParseOrbiter

### DIFF
--- a/Orbiter/Orbiter.m
+++ b/Orbiter/Orbiter.m
@@ -248,6 +248,7 @@ static NSString * const kParseAPIBaseURLString = @"https://api.parse.com/1/";
     ParseOrbiter *orbiter = [[ParseOrbiter alloc] initWithBaseURL:[NSURL URLWithString:kParseAPIBaseURLString] credential:nil];
     [orbiter.HTTPClient setDefaultHeader:@"X-Parse-Application-Id" value:applicationID];
     [orbiter.HTTPClient setDefaultHeader:@"X-Parse-REST-API-Key" value:RESTAPIKey];
+    orbiter.HTTPClient.parameterEncoding = AFJSONParameterEncoding;
     
     return orbiter;
 }


### PR DESCRIPTION
On first setup, I got the following error from Parse:
`{"code":107,"error":"This endpoint only supports Content-Type: application/json requests, not application/x-www-form-urlencoded."}`. Request headers were obviously wrong `"Content-Type" = "application/x-www-form-urlencoded; charset=utf-8"`. Seems like Parse requires json/application Content-Type for payload.

Now it works fine. Love this lightweight wrapper around push APIs (versus Parse's 5mb+ giant kit)!
