### PR TITLE
Fixing accepted content type

### DIFF
--- a/Orbiter/Orbiter.m
+++ b/Orbiter/Orbiter.m
@@ -72,6 +72,9 @@ static NSString * AFNormalizedDeviceTokenStringWithDeviceToken(id deviceToken) {
     [requestSerializer setValue:@"application/json" forHTTPHeaderField:@"Accept"];
     self.HTTPManager.requestSerializer = requestSerializer;
     
+    self.HTTPManager.responseSerializer = [AFHTTPResponseSerializer serializer];
+    [self.HTTPManager.responseSerializer setAcceptableContentTypes:[NSSet setWithObjects:@"application/json", @"text/plain", nil]];
+    
     return self;
 }
 


### PR DESCRIPTION
Urban Airship return an "OK" string which crashes with default content type (json). I just added text/plain to solve that.
