### PR TITLE
Non-existant property call

### DIFF
--- a/Orbiter/Orbiter.m
+++ b/Orbiter/Orbiter.m
@@ -100,7 +100,7 @@ static NSString * AFNormalizedDeviceTokenStringWithDeviceToken(id deviceToken) {
                     failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *mutablePayload = [NSMutableDictionary dictionary];
-    [mutablePayload setValue:[[NSLocale currentLocale] identifier] forKey:@"locale"];
+    [mutablePayload setValue:[[NSLocale currentLocale] localeIdentifier] forKey:@"locale"];
     [mutablePayload setValue:[[NSLocale preferredLanguages] objectAtIndex:0] forKey:@"language"];
     [mutablePayload setValue:[[NSTimeZone defaultTimeZone] name] forKey:@"timezone"];
     


### PR DESCRIPTION
Xcode 6 update identified this call "identifier" as non existant on class "NSLocale" and forbids me to compile.
I suspect that this call returns "nil" since for ever, or you are using without knowledge a private API.
