### PR TITLE
Fixed Parse Time Zone parameter name

### DIFF
--- a/Orbiter/Orbiter.m
+++ b/Orbiter/Orbiter.m
@@ -318,7 +318,7 @@ static NSString * const kParseAPIBaseURLString = @"https://api.parse.com/1/";
     }
     
     if (timeZone) {
-        [mutablePayload setValue:[timeZone name] forKey:@"tz"];
+        [mutablePayload setValue:[timeZone name] forKey:@"timeZone"];
     }
     
     [self registerDeviceToken:deviceToken withPayload:mutablePayload success:success failure:failure];


### PR DESCRIPTION
According to the Parse Docs:

https://parse.com/docs/rest#push

The parameter name for the user's Time Zone is listed as `timeZone` and not `tz`.
